### PR TITLE
Fix broken links to Github

### DIFF
--- a/lang/en_US/pages/gobolinux016.html
+++ b/lang/en_US/pages/gobolinux016.html
@@ -64,7 +64,7 @@ and a 64-bit library for a 64-bit process.
 <h2>GoboNet: daemon-free wireless network management</h2>
 
 <p>
-This release includes <a href="https://github.org/gobolinux/GoboNet">GoboNet</a>,
+This release includes <a href="https://github.com/gobolinux/GoboNet">GoboNet</a>,
 our own daemon-free network manager. Feature-heavy network managers like Wicd and
 NetworkManager are great at handling numerous complex scenarios, but the vast
 majority of the time something much simpler would do. And when the network
@@ -102,7 +102,7 @@ hand. </p>
 no-frills philosophy of Gobo:</p>
 
 <ul>
-<li>The Wi-Fi widget uses <a href="https://github.org/gobolinux/GoboNet">GoboNet</a></li></li>
+<li>The Wi-Fi widget uses <a href="https://github.com/gobolinux/GoboNet">GoboNet</a></li></li>
 <li>The battery widget checks the sysfs filesystem</li>
 <li>Our custom audio widget launches a transient frameless terminal running an instance of AlsaMixer that can be controlled via keyboard or mouse</li>
 </ul>

--- a/lang/en_US/pages/screenshots.html
+++ b/lang/en_US/pages/screenshots.html
@@ -6,7 +6,7 @@
 </div>
 <div class="screenshot_caption"><p>
 The custom Awesome WM environment shipped by default in GoboLinux, running Firefox, themed accordingly.
-The Wi-Fi widget uses <a href="https://github.org/gobolinux/GoboNet">GoboNet</a>, our own daemon-free network manager.
+The Wi-Fi widget uses <a href="https://github.com/gobolinux/GoboNet">GoboNet</a>, our own daemon-free network manager.
 </p></div>
 
 <div class="screenshot">
@@ -31,7 +31,7 @@ without conflicting with the rest of the system.
 <a href="<<root>>/images/gobo016installer.png"><img class="screenshot" src="<<root>>/images/gobo016installer.jpg"></a>
 </div>
 <div class="screenshot_caption"><p>
-The GoboLinux installer runs in either text or graphical mode, thanks to <a href="https://github.org/gobolinux/AbsTK">AbsTK</a>,
+The GoboLinux installer runs in either text or graphical mode, thanks to <a href="https://github.com/gobolinux/AbsTK">AbsTK</a>,
 the Abstract Toolkit we developed especially for building the Installer. It is a library that allows a 
 single codebase to produce a TUI and a GUI.
 </p></div>


### PR DESCRIPTION
A few links pointing to github dot org, which should point to github dot com.