### PR TITLE
Fix a broken link

### DIFF
--- a/lang/en_US/pages/k5.html
+++ b/lang/en_US/pages/k5.html
@@ -32,9 +32,9 @@ A bit of history
 We all remember the time when talking about Linux distributions for the
 desktop meant arguing which has the best installer. Much has evolved
 since: the easy, graphical installers are here, but we're <a
-href="http://www.linuxworld.com/2003/0401.tsu.html">not quite there
-yet</a>. Among the usual rants on "why (insert pet peeve here) is the
-problem", some interesting ideas come up from time to time. More 
+href="https://www.networkworld.com/article/2299325/the-view-from-2003--migrating-to-linux-not-easy-for-windows-users.html">not
+quite there yet</a>. Among the usual rants on "why (insert pet peeve here)
+is the problem", some interesting ideas come up from time to time. More
 interestingly, some people started to believe maybe it's time for more
 adventurous attempts.
 


### PR DESCRIPTION
http://www.linuxworld.com/2003/0401.tsu.html is no longer available.

For reference, the latest archive of that page still in the linuxworld.com domain is from [February 2010](https://web.archive.org/web/20100213121936/http://www.linuxworld.com/news/2007/051607-linux-migrating-windows-users.html).