### PR TITLE
Fix torrent download URL

### DIFF
--- a/lang/en_US/pages/downloads.html
+++ b/lang/en_US/pages/downloads.html
@@ -15,7 +15,7 @@ This is the latest stable release of GoboLinux, for x86_64. <a href="?page=gobol
 </p>
 <ul>
 <li><a href="https://github.com/gobolinux/LiveCD/releases/download/017/GoboLinux-017-x86_64.iso">GoboLinux-017-x86_64.iso</a> (HTTPS) -- thanks to GitHub, Inc.</b></li>
-<li><a href="http://gobolinux.org/iso/GoboLinux-017-x86_64.iso.torrent">GoboLinux-017-x86_64.iso.torrent</a> (BitTorrent) -- please help seeding!</li>
+<li><a href="https://gobolinux.org/iso/GoboLinux-017-x86_64.iso.torrent">GoboLinux-017-x86_64.iso.torrent</a> (BitTorrent) -- please help seeding!</li>
 
 </ul>
 


### PR DESCRIPTION
The BitTorrent download link doesn't work when accessing the page over HTTPS on Chrome.